### PR TITLE
feat: implement system tray behavior with show and quit actions

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/kirc/state.rs
+++ b/src-tauri/src/kirc/state.rs
@@ -19,4 +19,15 @@ impl IRCClientState {
             statuses: Mutex::new(HashMap::new()),
         }
     }
+
+    pub(crate) fn shutdown(&self) {
+        for server in self
+            .servers
+            .lock()
+            .expect("IRCClientState shutdown servers mutex poisoned")
+            .values()
+        {
+            let _ = server.tx.send(ServerCommand::Quit);
+        }
+    }
 }


### PR DESCRIPTION
- add system tray with Show and Quit menu items
- intercept window close event to hide instead of exiting
- restore main window on tray show action
- implement graceful shutdown on Quit (IRC disconnect + app exit)
- ensure cross-platform window restore handling (show, unminimize, focus)