### PR TITLE
Add channel lock support with Tauri commands and UI toggle

### DIFF
--- a/src-tauri/src/kirc/commands.rs
+++ b/src-tauri/src/kirc/commands.rs
@@ -1,6 +1,8 @@
 use crate::error::MyCustomError;
 use crate::kirc::core::server_actor;
-use crate::kirc::payloads::{ConnectServerPayload, ServerStatusPayload};
+use crate::kirc::payloads::{
+    ChannelLockChangedEvent, ChannelLockPayload, ConnectServerPayload, ServerStatusPayload,
+};
 use crate::kirc::state::{IRCClientState, ServerRuntime};
 use crate::kirc::types::{ServerCommand, ServerId, ServerStatus};
 use anyhow::{anyhow, Context};
@@ -80,12 +82,20 @@ pub(crate) fn send_message(
 ) -> Result<(), MyCustomError> {
     info!("Tauri command: send message invoked, server_id: {server_id}, target: {target}, message: {message}");
 
-    let servers = state.servers.lock().expect("Servers lock poisoned");
-    let server = servers.get(&server_id).context("Can't find server")?;
+    // 1. 정책 체크
+    if state.is_channel_locked(&server_id, &target)? {
+        return Err(MyCustomError::Anyhow(anyhow!("Channel is locked")));
+    }
 
-    if let ServerRuntime::Connected { tx, .. } = server {
+    // 2. 서버 runtime 접근
+    let servers = state.servers.lock().expect("Servers lock poisoned");
+    let runtime = servers.get(&server_id).context("Can't find server")?;
+
+    if let ServerRuntime::Connected { tx, .. } = runtime {
         tx.send(ServerCommand::Privmsg { target, message })
             .context("Failed to send privmsg")?;
+    } else {
+        return Err(MyCustomError::Anyhow(anyhow!("Server not connected")));
     }
 
     Ok(())
@@ -139,4 +149,85 @@ pub(crate) fn disconnect_server(
     }
 
     Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn lock_channel(
+    payload: ChannelLockPayload,
+    state: State<IRCClientState>,
+    app_handle: AppHandle,
+) -> Result<(), MyCustomError> {
+    {
+        let mut channels = state
+            .channel_states
+            .lock()
+            .map_err(|_| MyCustomError::Anyhow(anyhow!("Channels lock poisoned")))?;
+        let server_entry = channels.entry(payload.server_id.clone()).or_default();
+        let channel_state = server_entry.entry(payload.channel.clone()).or_default();
+
+        channel_state.locked = true;
+    }
+
+    app_handle
+        .emit(
+            "kirc:channel_lock_changed",
+            ChannelLockChangedEvent {
+                server_id: payload.server_id,
+                channel: payload.channel,
+                locked: true,
+            },
+        )
+        .context("Failed to send kirc:channel_lock_changed")?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn unlock_channel(
+    payload: ChannelLockPayload,
+    state: State<IRCClientState>,
+    app_handle: AppHandle,
+) -> Result<(), MyCustomError> {
+    {
+        let mut channels = state
+            .channel_states
+            .lock()
+            .map_err(|_| MyCustomError::Anyhow(anyhow!("Channels lock poisoned")))?;
+
+        if let Some(server_entry) = channels.get_mut(&payload.server_id) {
+            if let Some(channel_state) = server_entry.get_mut(&payload.channel) {
+                channel_state.locked = false;
+            }
+        }
+    }
+
+    app_handle
+        .emit(
+            "kirc:channel_lock_changed",
+            ChannelLockChangedEvent {
+                server_id: payload.server_id,
+                channel: payload.channel,
+                locked: false,
+            },
+        )
+        .context("Failed to send kirc:channel_lock_changed")?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn is_channel_locked(
+    payload: ChannelLockPayload,
+    state: State<IRCClientState>,
+) -> Result<bool, MyCustomError> {
+    let channels = state
+        .channel_states
+        .lock()
+        .map_err(|_| MyCustomError::Anyhow(anyhow!("Channels lock poisoned")))?;
+
+    Ok(channels
+        .get(&payload.server_id)
+        .and_then(|m| m.get(&payload.channel))
+        .map(|s| s.locked)
+        .unwrap_or(false))
 }

--- a/src-tauri/src/kirc/payloads.rs
+++ b/src-tauri/src/kirc/payloads.rs
@@ -65,3 +65,18 @@ pub(super) enum UiEventPayload {
         message: String,
     },
 }
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChannelLockPayload {
+    pub(super) server_id: ServerId,
+    pub(super) channel: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ChannelLockChangedEvent {
+    pub(super) server_id: ServerId,
+    pub(super) channel: String,
+    pub(super) locked: bool,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,9 @@ pub fn run() {
             kirc::commands::send_message,
             kirc::commands::cancel_connect,
             kirc::commands::disconnect_server,
+            kirc::commands::lock_channel,
+            kirc::commands::unlock_channel,
+            kirc::commands::is_channel_locked,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/routes/ChannelJoinModal.svelte
+++ b/src/routes/ChannelJoinModal.svelte
@@ -36,22 +36,6 @@
 
         invoke("join_channel", {serverId: serverId, channel: form.name});
 
-        /*servers.update((map) => {
-            const server = map.get(serverId);
-            if (!server) return map;
-
-            if (!server.channels.has(form.name)) {
-                server.channels.set(form.name, {
-                    name: form.name,
-                    messages: [],
-                    unread: 0,
-                });
-            }
-
-            return map;
-        });
-
-        currentChannelName.set(form.name);*/
         close();
     }
 

--- a/src/routes/ServerModal.svelte
+++ b/src/routes/ServerModal.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import {invoke} from "@tauri-apps/api/core";
     import {listen} from "@tauri-apps/api/event";
-    import type {IrcServerStatus} from "../types/irc_types.svelte";
+    import type {IrcServerStatus} from "../types/kirc.svelte";
     import {SvelteMap} from "svelte/reactivity";
     import {servers} from "../stores/stores.svelte";
-    import {ServerStatus} from "../types/dto.svelte";
-    import type {ServerStatusPayload} from "../types/payloads.svelte";
+    import {ServerStatus, type ServerStatusPayload} from "../types/payloads.svelte";
 
     interface Props {
         showServerModal: boolean;

--- a/src/types/dto.svelte.ts
+++ b/src/types/dto.svelte.ts
@@ -1,8 +1,0 @@
-export enum ServerStatus {
-    Connecting = "Connecting",
-    Connected = "Connected",
-    Registering = "Registering",
-    Disconnected = "Disconnected",
-    Disconnecting = "Disconnecting",
-    Failed = "Failed",
-}

--- a/src/types/kirc.svelte.ts
+++ b/src/types/kirc.svelte.ts
@@ -7,7 +7,7 @@ export type ChatMessage = | {
 }
 
 export type Channel = {
-    name: string; topic?: string; messages: ChatMessage[]; users: SvelteSet<string>; unread: number;
+    name: string; topic?: string; messages: ChatMessage[]; users: SvelteSet<string>; unread: number; locked: boolean;
 }
 
 export type Server = {

--- a/src/types/payloads.svelte.ts
+++ b/src/types/payloads.svelte.ts
@@ -1,4 +1,11 @@
-import type {ServerStatus} from "./dto.svelte";
+export enum ServerStatus {
+    Connecting = "Connecting",
+    Connected = "Connected",
+    Registering = "Registering",
+    Disconnected = "Disconnected",
+    Disconnecting = "Disconnecting",
+    Failed = "Failed",
+}
 
 export type ServerStatusPayload = {
     serverId: string, status: ServerStatus,
@@ -12,3 +19,9 @@ export type UiEventPayload =
     | { type: "Nick"; server_id: string; old_nick: string; new_nick: string }
     | { type: "Topic"; server_id: string; channel: string; topic?: string }
     | { type: "Error"; server_id: string; message: string };
+
+export type ChannelLockChangedEvent = {
+    serverId: string;
+    channel: string;
+    locked: boolean;
+}


### PR DESCRIPTION
- add channel lock state, payloads, and events
- expose lock/unlock/check commands in Tauri
- update store and UI to toggle lock and disable input
- rename IRC types file and clean up modal imports