### PR TITLE
fix: Use create_dir_all for app data path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,7 +51,7 @@ pub fn run() {
             }
 
             if !app_data_dir.exists() {
-                std::fs::create_dir(&app_data_dir)?;
+                std::fs::create_dir_all(&app_data_dir)?;
             }
             let config_path = app_data_dir.join("config.json");
             let snapshot: KircStateSnapshot = fs::load(&config_path).unwrap();


### PR DESCRIPTION
Use `create_dir_all` when initializing the application data directory. This ensures that all necessary parent directories are created, preventing initialization failures if the path structure is incomplete.