### PR TITLE
fix: Prevent sending empty messages from chat

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,6 +51,8 @@
     const sendMessage = async (): Promise<void> => {
         if (!ircStore.currentServerId || !ircStore.currentChannel) return;
 
+        if (msgInput.trim() === "") return;
+
         await invoke("send_message", {
             serverId: ircStore.currentServerId,
             target: ircStore.currentChannel.name,


### PR DESCRIPTION
Adds validation to ensure the message input is not empty before attempting to send it to the server.