### PR TITLE
feat: Add alternative nicknames to server config

### DIFF
--- a/src-tauri/src/kirc/core.rs
+++ b/src-tauri/src/kirc/core.rs
@@ -22,6 +22,10 @@ pub(super) async fn server_actor(
         port: Some(server_config.port()),
         use_tls: Some(server_config.use_tls()),
         nickname: Some(server_config.nickname().to_string()),
+        alt_nicks: vec![
+            format!("{}_", server_config.nickname()),
+            format!("{}__", server_config.nickname()),
+        ],
         ..Config::default()
     };
 


### PR DESCRIPTION
Configures alternative nicknames using suffixes
to improve connection resilience and handling naming conflicts.