### PR TITLE
refactor: Implement ServerInfo builder pattern, Simplify Kirc state handling and cleanup 

### DIFF
--- a/src-tauri/src/kirc/commands.rs
+++ b/src-tauri/src/kirc/commands.rs
@@ -31,16 +31,18 @@ pub(crate) fn get_servers(
             .map(|(name, s)| ChannelInfo::new(&name, s.locked))
             .collect();
 
-        infos.push(ServerInfo::new(
-            id,
-            config.server(),
-            config.server(),
-            config.port(),
-            config.use_tls(),
-            config.nickname(),
-            server_state.status(),
-            channel_infos,
-        ));
+        let server_info = ServerInfo::builder()
+            .id(id)
+            .name(config.server())
+            .host(config.server())
+            .port(config.port())
+            .tls(config.use_tls())
+            .nickname(config.nickname())
+            .status(server_state.status())
+            .channels(channel_infos)
+            .build();
+
+        infos.push(server_info);
     }
 
     Ok(infos)
@@ -256,26 +258,91 @@ mod payload {
     }
 
     impl ServerInfo {
-        pub(super) fn new(
-            id: ServerId,
-            name: &str,
-            host: &str,
-            port: u16,
-            tls: bool,
-            nickname: &str,
-            status: ServerStatus,
-            channels: Vec<ChannelInfo>,
-        ) -> Self {
-            Self {
-                id,
-                name: name.to_string(),
-                host: host.to_string(),
-                port,
-                tls,
-                nickname: nickname.to_string(),
-                status,
-                channels,
+        pub(super) fn builder() -> ServerInfoBuilder {
+            ServerInfoBuilder::new()
+        }
+    }
+
+    #[derive(Default)]
+    pub(super) struct ServerInfoBuilder {
+        id: Option<ServerId>,
+        name: Option<String>,
+        host: Option<String>,
+        port: Option<u16>,
+        tls: Option<bool>,
+        nickname: Option<String>,
+        status: Option<ServerStatus>,
+        channels: Option<Vec<ChannelInfo>>,
+    }
+
+    impl ServerInfoBuilder {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        pub(super) fn build(&self) -> ServerInfo {
+            if self.id.is_none()
+                || self.name.is_none()
+                || self.host.is_none()
+                || self.port.is_none()
+                || self.tls.is_none()
+                || self.nickname.is_none()
+                || self.status.is_none()
+                || self.channels.is_none()
+            {
+                panic!("ServerInfoBuilder: build() called with incomplete data");
             }
+
+            ServerInfo {
+                id: self.id.unwrap(),
+                name: self.name.clone().unwrap(),
+                host: self.host.clone().unwrap(),
+                port: self.port.unwrap(),
+                tls: self.tls.unwrap(),
+                nickname: self.nickname.clone().unwrap(),
+                status: self.status.clone().unwrap(),
+                channels: self.channels.clone().unwrap(),
+            }
+        }
+
+        pub(super) fn id(&mut self, id: ServerId) -> &mut Self {
+            self.id = Some(id);
+            self
+        }
+
+        pub(super) fn name(&mut self, name: &str) -> &mut Self {
+            self.name = Some(name.to_string());
+            self
+        }
+
+        pub(super) fn host(&mut self, host: &str) -> &mut Self {
+            self.host = Some(host.to_string());
+            self
+        }
+
+        pub(super) fn port(&mut self, port: u16) -> &mut Self {
+            self.port = Some(port);
+            self
+        }
+
+        pub(super) fn tls(&mut self, tls: bool) -> &mut Self {
+            self.tls = Some(tls);
+            self
+        }
+
+        pub(super) fn nickname(&mut self, nickname: &str) -> &mut Self {
+            self.nickname = Some(nickname.to_string());
+            self
+        }
+
+        pub(super) fn status(&mut self, status: ServerStatus) -> &mut Self {
+            self.status = Some(status);
+            self
+        }
+
+        pub(super) fn channels(&mut self, channels: Vec<ChannelInfo>) -> &mut Self {
+            self.channels = Some(channels);
+            self
         }
     }
 }

--- a/src-tauri/src/kirc/core.rs
+++ b/src-tauri/src/kirc/core.rs
@@ -135,7 +135,7 @@ fn handle_message(
     app_handle: &AppHandle,
 ) -> anyhow::Result<()> {
     // trace!(message = %format!("{message}").trim_end());
-    let source_nickname = message.source_nickname().unwrap_or_else(|| "").to_string();
+    let source_nickname = message.source_nickname().unwrap_or("").to_string();
 
     match message.command {
         Command::PRIVMSG(target, content) => {
@@ -143,7 +143,7 @@ fn handle_message(
                 .user_message(server_id, target, source_nickname, content)
                 .emit()?;
         }
-        Command::JOIN(chanlist, chankey, real_name) => {
+        Command::JOIN(chanlist, _chankey, _real_name) => {
             emit_ui_event(app_handle)
                 .join(server_id, chanlist, source_nickname)
                 .emit()?;
@@ -179,7 +179,7 @@ fn handle_message(
                     server.transition_to_connected();
 
                     // 기존 채널이 존재하면 연결
-                    for (channel_name, channel_state) in server.channels() {
+                    for (channel_name, _channel_state) in server.channels() {
                         server.send_command(ServerCommand::Join(channel_name))?;
                     }
                 }

--- a/src-tauri/src/kirc/persistence.rs
+++ b/src-tauri/src/kirc/persistence.rs
@@ -25,7 +25,7 @@ impl Memento<ServerState> for ServerStateSnapshot {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub(crate) struct KircStateSnapshot {
     servers: Vec<ServerStateSnapshot>,
 }
@@ -47,13 +47,5 @@ impl FromIterator<ServerStateSnapshot> for KircStateSnapshot {
 impl Memento<KircState> for KircStateSnapshot {
     fn restore(self) -> KircState {
         KircState::from_iter(self.servers)
-    }
-}
-
-impl Default for KircStateSnapshot {
-    fn default() -> Self {
-        Self {
-            servers: Vec::new(),
-        }
     }
 }

--- a/src-tauri/src/kirc/state/kirc.rs
+++ b/src-tauri/src/kirc/state/kirc.rs
@@ -14,13 +14,6 @@ pub(crate) struct KircState {
 }
 
 impl KircState {
-    pub(crate) fn new() -> Self {
-        Self {
-            servers: Mutex::new(HashMap::new()),
-            persistence_path: None,
-        }
-    }
-
     pub(crate) fn set_persistence_path(&mut self, path: &std::path::Path) {
         self.persistence_path = Some(path.to_path_buf());
     }
@@ -87,6 +80,6 @@ impl FromIterator<ServerStateSnapshot> for KircState {
 impl Originator<KircStateSnapshot> for KircState {
     fn snapshot(&self) -> KircStateSnapshot {
         let servers = self.servers.lock().unwrap();
-        KircStateSnapshot::from_iter(servers.iter().map(|(_, state)| state.snapshot()))
+        KircStateSnapshot::from_iter(servers.values().map(|state| state.snapshot()))
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,5 @@
 use crate::kirc::manager::KircManager;
 use crate::kirc::persistence::KircStateSnapshot;
-use crate::logging::init_logging;
 use crate::memento::Memento;
 use anyhow::Context;
 use std::sync::Arc;


### PR DESCRIPTION
- Adopts the Builder pattern for creating `ServerInfo` structures in command handlers.
- Removes redundant `Default` implementations and simplifies initialization logic across `KircState` and `KircStateSnapshot`.
- Cleans up unused parameters and imports throughout the module. 