### PR TITLE
feature: change nickname

### DIFF
--- a/src-tauri/src/kirc/commands.rs
+++ b/src-tauri/src/kirc/commands.rs
@@ -1,14 +1,12 @@
 use crate::error::MyCustomError;
-use crate::kirc::commands::payload::{
-    ChannelInfo, ChannelPayload, ConnectServerPayload, ServerInfo,
-};
+use crate::kirc::commands::payload::{ChangeNickPayload, ChannelInfo, ChannelPayload, ConnectServerPayload, ServerInfo};
 use crate::kirc::manager::KircManager;
 use crate::kirc::state::kirc::KircState;
-use crate::kirc::types::ServerId;
+use crate::kirc::types::{ServerCommand, ServerId};
 use anyhow::Context;
 use std::sync::Arc;
 use tauri::{AppHandle, State};
-use tracing::info;
+use tracing::{info, instrument};
 
 #[tauri::command]
 pub(crate) async fn init_servers(manager: State<'_, KircManager>) -> Result<(), MyCustomError> {
@@ -103,7 +101,7 @@ pub(crate) fn send_message(
 
     // 2. 서버 runtime 접근
     let server = state.get_server(server_id).context("Can't find server")?;
-    server.send_command(crate::kirc::types::ServerCommand::Privmsg { target, message })?;
+    server.send_command(ServerCommand::Privmsg { target, message })?;
 
     Ok(())
 }
@@ -180,6 +178,19 @@ pub(crate) fn is_channel_locked(
     state: State<'_, Arc<KircState>>,
 ) -> Result<bool, MyCustomError> {
     Ok(state.is_channel_locked(payload.server_id(), payload.channel()))
+}
+
+#[tauri::command]
+#[instrument(skip(state), fields(server_id = %payload.server_id))]
+pub(crate) fn change_nickname(payload: ChangeNickPayload, state: State<Arc<KircState>>) -> Result<(), MyCustomError> {
+    info!(event="change_nickname", new_nick=%payload.new_nick, "Tauri command: change nickname invoked");
+    
+    let server = state.get_server(payload.server_id).context("Can't find server")?;
+    server.send_command(ServerCommand::Nick(payload.new_nick))?;
+    
+    // 닉네임 변경시 core::handle_message에서 자동으로 ui_event가 emit 됨
+    
+    Ok(())
 }
 
 mod payload {
@@ -344,5 +355,13 @@ mod payload {
             self.channels = Some(channels);
             self
         }
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[derive(Debug)]
+pub(crate) struct ChangeNickPayload {
+        pub(super) server_id: ServerId,
+        pub(super) new_nick: String,
     }
 }

--- a/src-tauri/src/kirc/core.rs
+++ b/src-tauri/src/kirc/core.rs
@@ -1,4 +1,4 @@
-use crate::kirc::emits::{emit_server_status, emit_system_message, emit_ui_event};
+use crate::kirc::emits::{emit_change_nick_failed, emit_server_status, emit_system_message, emit_ui_event};
 use crate::kirc::state::kirc::KircState;
 use crate::kirc::types::server::ServerConfig;
 use crate::kirc::types::{ServerCommand, ServerId, ServerStatus};
@@ -6,9 +6,9 @@ use futures::prelude::*;
 use irc::client::prelude::*;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
-use tracing::{debug, error, instrument, trace};
+use tracing::{debug, error, info, instrument, trace, warn};
 
-#[instrument(skip(app_handle))]
+#[instrument(name = "server_actor", skip_all, fields(server_id = %server_id))]
 pub(super) async fn server_actor(
     server_id: ServerId,
     server_config: ServerConfig,
@@ -22,10 +22,12 @@ pub(super) async fn server_actor(
         port: Some(server_config.port()),
         use_tls: Some(server_config.use_tls()),
         nickname: Some(server_config.nickname().to_string()),
-        alt_nicks: vec![
+        // alt 닉네임 직접 제어
+        /*alt_nicks: vec![
             format!("{}_", server_config.nickname()),
             format!("{}__", server_config.nickname()),
-        ],
+        ],*/
+        alt_nicks: vec![],
         ..Config::default()
     };
 
@@ -67,14 +69,33 @@ pub(super) async fn server_actor(
             Some(result) = stream.next() => {
                 match result {
                     Ok(message) => {
+                        debug!(event = "irc_message", command = ?message.command);
                         let _ = handle_message(server_id, message, &app_handle);
                     }
-                    Err(_) => break,
+                    Err(irc::error::Error::NoUsableNick) => {
+                        // 사용 가능한 닉네임이 없을때 (단순 닉네임 중복 등)
+                        // 처음부터 사용가능한 닉네임이 없었다면 identify에서 걸렸을테니 break 하지 않고 continue
+                        debug!(event = "irc_stream_error", error = "NoUsableNick", "IRC stream error, No usable nick");
+
+                        // 닉네임 변경은 alt_nick 없이 실패시 emit 후 바로 continue
+                        let _ = emit_change_nick_failed(&app_handle, server_id, "Can't change nickname");
+
+                        continue
+                    }
+                    Err(e) => {
+                        error!(
+                            event = "irc_stream_error",
+                            error = ?e,
+                            "IRC stream error, connection likely closed"
+                        );
+                        break
+                    },
                 }
             }
             Some(cmd) = rx.recv() => {
                 match cmd {
                     ServerCommand::Join(ch) => {
+                        info!(event = "join", channel = %ch);
                         if let Err(e) = client.send_join(&ch) {
                             error!("Failed to send join message: {e}");
                         }
@@ -84,7 +105,16 @@ pub(super) async fn server_actor(
                             error!("Failed to send privmsg: {e}");
                         }
 
-                        match Message::with_tags(None, Some(client.current_nickname()), "PRIVMSG", vec![&target, &message]) {
+                        let current_nick = {
+                            let state = app_handle.state::<Arc<KircState>>();
+                            if let Some(server) = state.get_server(server_id) {
+                                &server.current_nickname()
+                            } else {
+                                ""
+                            }
+                        };
+
+                        match Message::with_tags(None, Some(&current_nick), "PRIVMSG", vec![&target, &message]) {
                                 Ok(msg) => {
                                     handle_message(server_id, msg, &app_handle).expect("Failed to handle message");
                                 }
@@ -96,6 +126,12 @@ pub(super) async fn server_actor(
                     ServerCommand::Part { channel_name } => {
                         if let Err(e) = client.send_part(&channel_name) {
                             error!("Failed to send part: {e}");
+                        }
+                    }
+                    ServerCommand::Nick( new_nick ) => {
+                        info!(event = "nick", new_nick = %new_nick);
+                        if let Err(e) = client.send(Command::NICK(new_nick.to_owned())) {
+                            error!(event = "nick_send_failed", command = "NICK", new_nick = %new_nick, error = %e, "failed to send IRC NICK command");
                         }
                     }
                     ServerCommand::Quit => {
@@ -115,6 +151,7 @@ pub(super) async fn server_actor(
             server.transition_to_disconnected();
         }
     }
+
     let _ = emit_server_status(&app_handle, server_id, ServerStatus::Disconnected);
 }
 
@@ -134,7 +171,6 @@ fn handle_message(
     message: Message,
     app_handle: &AppHandle,
 ) -> anyhow::Result<()> {
-    // trace!(message = %format!("{message}").trim_end());
     let source_nickname = message.source_nickname().unwrap_or("").to_string();
 
     match message.command {
@@ -159,6 +195,23 @@ fn handle_message(
                 .emit()?;
         }
         Command::NICK(nickname) => {
+            // 1. 자기 자신인지 확인
+            let state = app_handle.state::<Arc<KircState>>();
+            if let Some(server) = state.get_server(server_id) {
+                if server.current_nickname() == source_nickname {
+                    server.set_current_nickname(&nickname);
+                }
+            }
+
+            // 지금은 백엔드에서 유저목록 관리 x, 나중에 변경될 수 있음
+            // 2. 모든 채널에서 유저 닉 변경
+            /*for channel in state.channels.values_mut() {
+                if channel.users.remove(&old_nick) {
+                    channel.users.insert(new_nick.clone());
+                }
+            }*/
+
+            // 3. 프론트로 이벤트 emit
             emit_ui_event(app_handle)
                 .nick(server_id, source_nickname, nickname)
                 .emit()?;
@@ -169,6 +222,7 @@ fn handle_message(
                 .emit()?;
         }
         Command::ERROR(message) => {
+            warn!(message = %message, "Server command error");
             emit_ui_event(app_handle).error(server_id, message).emit()?;
         }
         Command::Response(Response::RPL_WELCOME, _) => {
@@ -189,6 +243,12 @@ fn handle_message(
 
             // Optional: Alert system message
             emit_system_message(app_handle, server_id, "서버에 연결되었습니다.")?;
+        }
+        Command::Response(Response::ERR_NICKNAMEINUSE, _) => {
+            // 닉네임이 중복된 경우
+            // alt nick으로 재시도
+            // 그래도 안될경우 오류 던지기
+            trace!("닉네임 중복");
         }
         _ => {
             // TODO: Command 다른것도 추가하기

--- a/src-tauri/src/kirc/emits.rs
+++ b/src-tauri/src/kirc/emits.rs
@@ -1,7 +1,4 @@
-use crate::kirc::emits::payload::{
-    ChannelLockChangedEvent, ServerDetail, ServerStatusPayload, SystemMessagePayload,
-    UIEventPayload,
-};
+use crate::kirc::emits::payload::{ChangeNickFailedPayload, ChannelLockChangedEvent, ServerDetail, ServerStatusPayload, SystemMessagePayload, UIEventPayload};
 use crate::kirc::types::{ServerId, ServerStatus};
 use tauri::{AppHandle, Emitter};
 use tracing::trace;
@@ -197,6 +194,12 @@ pub(super) fn emit_system_message(
     Ok(())
 }
 
+pub(super) fn emit_change_nick_failed(app_handle: &AppHandle, server_id: ServerId, reason: &str) -> anyhow::Result<()> {
+    app_handle.emit("kirc:change_nick_failed", ChangeNickFailedPayload::new(server_id, reason))?;
+
+    Ok(())
+}
+
 mod payload {
     use crate::kirc::types::{ChannelId, ServerId, ServerStatus};
     use serde::Serialize;
@@ -319,5 +322,21 @@ mod payload {
             server_id: ServerId,
             message: String,
         },
+    }
+
+    #[derive(Serialize, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub(super) struct ChangeNickFailedPayload {
+        server_id: ServerId,
+        reason: String,
+    }
+
+    impl ChangeNickFailedPayload {
+        pub(super) fn new(server_id: ServerId, reason: &str) -> Self {
+            Self {
+                server_id,
+                reason: reason.to_string()
+            }
+        }
     }
 }

--- a/src-tauri/src/kirc/state/server.rs
+++ b/src-tauri/src/kirc/state/server.rs
@@ -80,12 +80,14 @@ pub(in crate::kirc) struct ServerState {
     runtime: Mutex<ServerRuntime>,
     config: Mutex<ServerConfig>,
     channels: Mutex<HashMap<ChannelId, ChannelState>>,
+    current_nickname: Mutex<String>,
 }
 
 impl ServerState {
     pub(in crate::kirc) fn new(runtime: ServerRuntime, config: ServerConfig) -> Self {
         Self {
             runtime: Mutex::new(runtime),
+            current_nickname: Mutex::new(config.nickname().to_string()),
             config: Mutex::new(config),
             channels: Mutex::new(HashMap::new()),
         }
@@ -97,6 +99,7 @@ impl ServerState {
     ) -> Self {
         Self {
             runtime: Mutex::new(ServerRuntime::Disconnected),
+            current_nickname: Mutex::new(config.nickname().to_string()),
             config: Mutex::new(config),
             channels: Mutex::new(channels),
         }
@@ -126,6 +129,14 @@ impl ServerState {
 
     pub(in crate::kirc) fn remove_channel(&self, channel_name: &str) -> Option<ChannelState> {
         self.channels.lock().unwrap().remove(channel_name)
+    }
+
+    pub(in crate::kirc) fn current_nickname(&self) -> String {
+        self.current_nickname.lock().unwrap().clone()
+    }
+
+    pub(in crate::kirc) fn set_current_nickname(&self, new_nick: &str) {
+        *self.current_nickname.lock().unwrap() = new_nick.to_string();
     }
 
     pub(in crate::kirc) fn is_active(&self) -> bool {

--- a/src-tauri/src/kirc/types.rs
+++ b/src-tauri/src/kirc/types.rs
@@ -22,6 +22,7 @@ pub(in crate::kirc) enum ServerCommand {
     Join(String),
     Privmsg { target: String, message: String },
     Part { channel_name: String },
+    Nick(String),
     Quit,
 }
 
@@ -31,6 +32,7 @@ impl Display for ServerCommand {
             ServerCommand::Join(x) => write!(f, "Join, {x}"),
             ServerCommand::Privmsg { target, message } => write!(f, "Privmsg, {target}, {message}"),
             ServerCommand::Part { channel_name } => write!(f, "Part, {channel_name}"),
+            ServerCommand::Nick(new_nick) => write!(f, "Nick, {new_nick}"),
             ServerCommand::Quit => write!(f, "Quit"),
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ pub fn run() {
             kirc::commands::lock_channel,
             kirc::commands::unlock_channel,
             kirc::commands::is_channel_locked,
+            kirc::commands::change_nickname
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -21,10 +21,12 @@ pub(super) fn init_logging() {
     let console_layer = tracing_subscriber::fmt::layer()
         .compact()
         .with_target(false)
+        .with_level(true)
         .with_thread_ids(false)
         .with_file(false)
         .with_line_number(false)
-        .with_span_events(FmtSpan::CLOSE);
+        .with_span_events(FmtSpan::CLOSE)
+        .json();
 
     tracing_subscriber::registry()
         .with(filter)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,11 +7,13 @@
     import {ircStore} from "../stores/irc.svelte";
     import {ircService} from "../services/ircService";
     import type {ChannelId, ServerId} from "../types/kirc.svelte.ts";
+    import ChangeNicknameModal from "./ChangeNicknameModal.svelte";
 
     let showChannelModal = $state<boolean>(false);
     let msgInput = $state<string>("");
 
     let showServerModal = $state<boolean>(false);
+    let showChangeNickModal = $state<boolean>(false)
 
     let channelContextMenu = $state<{
         visible: boolean,
@@ -105,6 +107,10 @@
 
     const disconnectServer = () => {
         invoke("disconnect_server", {serverId: serverContextMenu.serverId});
+    }
+
+    const changeNickname = () => {
+        showChangeNickModal = true
     }
 </script>
 
@@ -224,6 +230,15 @@
     <ServerModal bind:showServerModal></ServerModal>
 {/if}
 
+{#if serverContextMenu.visible }
+    <div class="fixed z-50 rounded bg-neutral-800 text-white shadow"
+         style="left: {channelContextMenu.x}px; top: {channelContextMenu.y}px;">
+        <button>Connect</button>
+        <button onclick={disconnectServer}>Disconnect</button>
+        <button>Copy Server Name</button>
+        <button onclick={changeNickname}>Change Nickname</button>
+    </div>
+{/if}
 {#if channelContextMenu.visible }
     <div class="fixed z-50 rounded bg-neutral-800 text-white shadow"
          style="left: {channelContextMenu.x}px; top: {channelContextMenu.y}px;">
@@ -232,13 +247,8 @@
         <button>Copy Channel Name</button>
     </div>
 {/if}
-{#if serverContextMenu.visible }
-    <div class="fixed z-50 rounded bg-neutral-800 text-white shadow"
-         style="left: {channelContextMenu.x}px; top: {channelContextMenu.y}px;">
-        <button>Connect</button>
-        <button onclick={disconnectServer}>Disconnect</button>
-        <button>Copy Server Name</button>
-    </div>
-{/if}
+
+<ChangeNicknameModal bind:showModal={showChangeNickModal} serverId={serverContextMenu.serverId}/>
+
 <style>
 </style>

--- a/src/routes/ChangeNicknameModal.svelte
+++ b/src/routes/ChangeNicknameModal.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+import Modal from "./Modal.svelte";
+import type {ServerId} from "../types/kirc.svelte";
+import {invoke} from "@tauri-apps/api/core";
+
+let {serverId, showModal = $bindable()}: {serverId: ServerId | null, showModal: boolean} = $props();
+
+type ChangeNickForm = {
+    serverId: ServerId,
+    newNick: string,
+}
+
+let form = $state<ChangeNickForm>({
+    serverId: "",
+    newNick: ""
+});
+
+const changeNickSubmit = () => {
+    if (!serverId) return;
+
+    form.serverId = serverId;
+
+    invoke("change_nickname")
+};
+</script>
+
+<Modal bind:showModal>
+    {#snippet header()}
+        <header class="mb-4 text-lg font-semibold">닉네임 변경</header>
+    {/snippet}
+
+    <form class="space-y-3" onsubmit={changeNickSubmit}>
+        <input bind:value={form.newNick}
+               class="w-full rounded-md border px-3 py-2 dark:bg-neutral-800"
+               placeholder="새 닉네임"
+        >
+
+        <!-- Actions -->
+        <footer class="flex justify-end gap-2 pt-4">
+            <button
+                    class="rounded-md px-3 py-1.5 text-sm hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                    onclick={() => showModal = false}
+                    type="button"
+            >
+                취소
+            </button>
+            <button
+                    class="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+                    type="submit"
+            >
+                추가
+            </button>
+        </footer>
+    </form>
+</Modal>

--- a/src/routes/ChangeNicknameModal.svelte
+++ b/src/routes/ChangeNicknameModal.svelte
@@ -2,25 +2,47 @@
 import Modal from "./Modal.svelte";
 import type {ServerId} from "../types/kirc.svelte";
 import {invoke} from "@tauri-apps/api/core";
+import {ircStore} from "../stores/irc.svelte";
 
 let {serverId, showModal = $bindable()}: {serverId: ServerId | null, showModal: boolean} = $props();
-
 type ChangeNickForm = {
-    serverId: ServerId,
     newNick: string,
 }
 
 let form = $state<ChangeNickForm>({
-    serverId: "",
     newNick: ""
+});
+let error: string | null = $derived.by(() => serverId ? ircStore.nickErrors.get(serverId) ?? null : null);
+let successNick: string | null = $derived.by(() => serverId ? ircStore.nickSuccess.get(serverId) ?? null : null);
+
+$effect(() => {
+    $inspect.trace("On change nick modal close");
+    if (!showModal) {
+        if (serverId) {
+            ircStore.nickErrors.delete(serverId);
+        }
+        form.newNick = "";
+    }
+});
+
+$effect(() => {
+    $inspect.trace("On change nick success");
+    if (successNick && showModal) {
+        showModal = false;
+        // showModal을 변경하니까 nickErrors랑 newNick은 위 effect에서 초기화 될듯
+
+        if (serverId) {
+            ircStore.nickSuccess.delete(serverId);
+        }
+    }
 });
 
 const changeNickSubmit = () => {
     if (!serverId) return;
 
-    form.serverId = serverId;
+    ircStore.nickErrors.delete(serverId);
 
-    invoke("change_nickname")
+    invoke("change_nickname", {payload: {serverId: serverId, newNick: form.newNick}});
 };
 </script>
 
@@ -35,6 +57,10 @@ const changeNickSubmit = () => {
                placeholder="새 닉네임"
         >
 
+        {#if error}
+            <p class="text-sm text-red-500">{error}</p>
+        {/if}
+
         <!-- Actions -->
         <footer class="flex justify-end gap-2 pt-4">
             <button
@@ -48,7 +74,7 @@ const changeNickSubmit = () => {
                     class="rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
                     type="submit"
             >
-                추가
+                변경
             </button>
         </footer>
     </form>

--- a/src/routes/Modal.svelte
+++ b/src/routes/Modal.svelte
@@ -20,7 +20,7 @@
     });
 </script>
 
-<dialog bind:this={dialog} class="m-auto rounded-md" onclose={() => showModal = false} onclick={(e) => {if (e.target === dialog) dialog.close();}}>
+<dialog bind:this={dialog} class="m-auto rounded-md" onclose={() => showModal = false}>
     <div class="w-80 rounded bg-white dark:bg-neutral-800 p-4 shadow-lg">
         {@render header?.()}
         {@render children?.()}

--- a/src/routes/Modal.svelte
+++ b/src/routes/Modal.svelte
@@ -2,17 +2,28 @@
     import type {Snippet} from "svelte";
 
     interface Props {
-        dialog: HTMLDialogElement,
+        showModal: boolean,
         header: Snippet,
         children: Snippet
     }
 
-    let {dialog = $bindable(), header, children}: Props = $props();
+    let {showModal = $bindable(), header, children}: Props = $props();
+
+    let dialog = $state<HTMLDialogElement>();
+
+    $effect(() => {
+        if (showModal) {
+            dialog?.showModal();
+        } else {
+            dialog?.close();
+        }
+    });
 </script>
 
-<dialog bind:this={dialog} class="m-auto rounded-md" onclick={(e) => {if (e.target === dialog) dialog.close()}}>
+<dialog bind:this={dialog} class="m-auto rounded-md" onclose={() => showModal = false} onclick={(e) => {if (e.target === dialog) dialog.close();}}>
     <div class="w-80 rounded bg-white dark:bg-neutral-800 p-4 shadow-lg">
         {@render header?.()}
         {@render children?.()}
+<!--        <button onclick={() => dialog?.close()}>닫기</button>-->
     </div>
 </dialog>

--- a/src/services/ircService.ts
+++ b/src/services/ircService.ts
@@ -10,7 +10,7 @@ import {
   MessageType,
   type ServerId,
 } from "../types/kirc.svelte";
-import type { ChannelLockChangedEvent, UiEventPayload } from "../types/payloads.svelte";
+import type {ChangeNickFailedPayload, ChannelLockChangedEvent, UiEventPayload} from "../types/payloads.svelte";
 
 export class IrcService {
   async initialize() {
@@ -24,11 +24,11 @@ export class IrcService {
       });
     });
 
-    this.setupEventListeners();
+    await this.setupEventListeners();
   }
 
-  private setupEventListeners() {
-    listen<UiEventPayload>("kirc:event", (event) => {
+  private async setupEventListeners() {
+    await listen<UiEventPayload>("kirc:event", (event) => {
       const payload = event.payload;
 
       switch (payload.type) {
@@ -121,8 +121,15 @@ export class IrcService {
         case "Nick": {
           const server = ircStore.servers.get(payload.server_id);
           if (server) {
+            // 내 닉네임이 변경된거면 server.nickname 수정하기
             if (server.nickname === payload.old_nick) {
               server.nickname = payload.new_nick;
+
+              ircStore.servers.set(payload.server_id, {
+                ...server,
+                nickname: payload.new_nick
+              });
+              ircStore.nickSuccess.set(payload.server_id, payload.new_nick);
             }
             for (const channel of ircStore.channels.values()) {
               if (channel.serverId === payload.server_id && channel.users.has(payload.old_nick)) {
@@ -175,8 +182,8 @@ export class IrcService {
       }
     });
 
-    listen<any>("kirc:server_status", (event) => {
-      const { serverId, status } = event.payload;
+    await listen<any>("kirc:server_status", (event) => {
+      const {serverId, status} = event.payload;
       const server = ircStore.servers.get(serverId);
       if (server) {
         ircStore.servers.set(serverId, {
@@ -186,7 +193,7 @@ export class IrcService {
       }
     });
 
-    listen<any>("kirc:server_added", (event) => {
+    await listen<any>("kirc:server_added", (event) => {
       const payload = event.payload;
       if (ircStore.servers.has(payload.serverId)) return;
 
@@ -202,9 +209,14 @@ export class IrcService {
       });
     });
 
-    listen<ChannelLockChangedEvent>("kirc:channel_lock_changed", (event) => {
+    await listen<ChannelLockChangedEvent>("kirc:channel_lock_changed", (event) => {
       const { channel, locked } = event.payload;
       this.updateChannelLock(channel, locked);
+    });
+
+    await listen<ChangeNickFailedPayload>('kirc:change_nick_failed', (event) => {
+      const {serverId, reason} = event.payload;
+      ircStore.nickErrors.set(serverId, reason);
     });
   }
 

--- a/src/stores/irc.svelte.ts
+++ b/src/stores/irc.svelte.ts
@@ -7,6 +7,8 @@ export class IrcStore {
   messages = $state(new SvelteMap<ChannelId, ChatMessage[]>());
   currentServerId = $state<ServerId | null>(null);
   currentChannelId = $state<ChannelId | null>(null);
+  nickErrors = $state(new SvelteMap<ServerId, string>());
+  nickSuccess = $state(new SvelteMap<ServerId, string>());
 
   currentServer = $derived.by(() => {
     if (!this.currentServerId) return null;

--- a/src/types/payloads.svelte.ts
+++ b/src/types/payloads.svelte.ts
@@ -1,3 +1,5 @@
+import type {ServerId} from "./kirc.svelte";
+
 export enum ServerStatus {
   Connecting = "Connecting",
   Connected = "Connected",
@@ -41,4 +43,9 @@ export type ChannelLockChangedEvent = {
   serverId: string;
   channel: string;
   locked: boolean;
+};
+
+export type ChangeNickFailedPayload = {
+    serverId: ServerId;
+    reason: string
 };


### PR DESCRIPTION
- Added the `change_nickname` command
- Removed the `alt_nicks` setting
- Added handling for the `NoUsableNick` error (duplicate nickname) within the loop
- Added `current_nickname` to `ServerState` to track the actual nickname rather than the one in the initial config
- Added `ServerCommand::Nick` and implemented the functionality to send it to the server
- Added emit events for successful and failed nickname changes, and added event handling
- Modified logging settings