### PR TITLE
refactor: Update application name and identifiers to 'kirc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ deno task fmt:check
 
 앱 종료 시 서버 설정과 채널 목록이 OS 앱 데이터 디렉토리에 `config.json`으로 저장됩니다.
 
-- **macOS**: `~/Library/Application Support/com.kimtalmo.irc-client/config.json`
-- **Windows**: `%APPDATA%\com.kimtalmo.irc-client\config.json`
-- **Linux**: `~/.local/share/com.kimtalmo.irc-client/config.json`
+- **macOS**: `~/Library/Application Support/com.kimtalmo.kirc/config.json`
+- **Windows**: `%APPDATA%\com.kimtalmo.kirc\config.json`
+- **Linux**: `~/.local/share/com.kimtalmo.kirc/config.json`
 
 저장되는 정보: 서버 호스트·포트·TLS·닉네임, 참가 중인 채널 목록 및 잠금 상태.  
 메시지 히스토리는 세션 내 메모리에만 유지되며 저장되지 않습니다.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "irc-client",
+  "name": "kirc",
   "version": "0.1.0",
   "description": "",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "irc-client"
+name = "kirc"
 version = "0.1.0"
-description = "A Tauri App"
+description = "IRC client built with Tauri"
 authors = ["you"]
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "irc-client",
+  "productName": "kirc",
   "version": "0.1.0",
-  "identifier": "com.kimtalmo.irc-client",
+  "identifier": "com.kimtalmo.kirc",
   "build": {
     "beforeDevCommand": "deno task dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "irc-client",
+        "title": "kirc",
         "width": 800,
         "height": 600
       }


### PR DESCRIPTION
Updates the application's product name, package names, and OS identifiers across `package.json`, `Cargo.toml`, `tauri.conf.json`, and `README.md` to standardize the project name from 'irc-client' to 'kirc'.