### PR TITLE
chore: Upgrade CI platforms and update release naming

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
             args: '--target aarch64-apple-darwin'
 #          - platform: 'macos-latest' # for Intel based macs.
 #            args: '--target x86_64-apple-darwin'
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             args: ''
           - platform: 'windows-latest'
             args: ''
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -40,7 +40,7 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        if: matrix.platform == 'ubuntu-24.04' # This must match the platform value defined above.
         run: |
           sudo apt update
           sudo apt install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
@@ -54,9 +54,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
-          releaseName: 'App v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
+          tagName: kirc-rs-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'kirc-rs v__VERSION__'
+          releaseBody: 'See the assets to download this version and install.' # TODO: Provide a more detailed explanation.
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}


### PR DESCRIPTION
Updates the GitHub Actions workflow to use the latest stable platforms:

- Migrates dependency setup from Ubuntu 22.04 to 24.04.
- Upgrades `actions/setup-node` to version 6.
- Updates artifact and release metadata to reflect the `kirc-rs` project name.